### PR TITLE
室外降落rst里面的单独进行二维码检测命令由roslaunch prometheus_detection landpad_det.laun…

### DIFF
--- a/doc/source/docs/p450/5-进阶功能-室外自主避障.rst
+++ b/doc/source/docs/p450/5-进阶功能-室外自主避障.rst
@@ -98,4 +98,4 @@
 
 .. raw:: html
 
-    <iframe src="//player.bilibili.com/player.html?aid=289495747&bvid=BV1sf4y1478z&cid=318713470&page=16" scrolling="no" border="0" frameborder="no" framespacing="0" allowfullscreen="true"> </iframe>
+    <iframe  width="696" height="422" src="//player.bilibili.com/player.html?aid=289495747&bvid=BV1sf4y1478z&cid=318713470&page=16" scrolling="no" border="0" frameborder="no" framespacing="0" allowfullscreen="true"> </iframe>

--- a/doc/source/docs/p450/5-进阶功能-室外自主降落.rst
+++ b/doc/source/docs/p450/5-进阶功能-室外自主降落.rst
@@ -27,7 +27,7 @@
 
 运行检测节点
 
-`roslaunch prometheus_detection landpad_det.launch`
+`roslaunch p450_experiment p450_landpad_det.launch`
 
 查看检测效果（可视化）
 


### PR DESCRIPTION
…ch改为roslaunch p450_experiment p450_landpad_det.launch，P450上用这个。之前改了室内二维码降落rst里面的这个命令，忘记改室外二维码降落rst的里面的这个命令了。